### PR TITLE
Add SAST and code coverage reports

### DIFF
--- a/.github/workflows/deploy-site.yaml
+++ b/.github/workflows/deploy-site.yaml
@@ -49,7 +49,7 @@ jobs:
           ./mvnw \
           --show-version --batch-mode --errors --no-transfer-progress \
           -Prelease \
-          process-classes site site:stage
+          verify site site:stage
 
       - name: Upload static site
         uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # 3.0.1


### PR DESCRIPTION
By running a complete build, the SAST and code coverage reports will be included in the website.