### PR TITLE
Skip GPG signing

### DIFF
--- a/.github/workflows/deploy-site.yaml
+++ b/.github/workflows/deploy-site.yaml
@@ -48,6 +48,7 @@ jobs:
         run: |
           ./mvnw \
           --show-version --batch-mode --errors --no-transfer-progress \
+          -Dgpg.skip \
           -Prelease \
           verify site site:stage
 


### PR DESCRIPTION
GPG signing during site generation fails the build.